### PR TITLE
fix: apply ASR config values

### DIFF
--- a/apiservice/biz/asr/asr.go
+++ b/apiservice/biz/asr/asr.go
@@ -64,15 +64,15 @@ func RecognizeAudioHandler(ctx context.Context, c *app.RequestContext) {
 	})
 }
 
-func InitModelCfg(appID, token, cluster string) error {
-	if appID == "" || token == "" || cluster == "" {
+func InitModelCfg(appIDValue, tokenValue, clusterValue string) error {
+	if appIDValue == "" || tokenValue == "" || clusterValue == "" {
 		return fmt.Errorf("AsrModel.AppID=%s, AsrModel.Token=%s, AsrModel.Cluster=%s,"+
-			"please check your config file", appID, token, cluster)
+			"please check your config file", appIDValue, tokenValue, clusterValue)
 	}
 	once.Do(func() {
-		appID = appID
-		token = token
-		cluster = cluster
+		appID = appIDValue
+		token = tokenValue
+		cluster = clusterValue
 	})
 	return nil
 }


### PR DESCRIPTION
## Background
Browser voice input always failed. Root cause: ASR config values were not assigned to global variables due to parameter shadowing, leaving appID/token/cluster empty.

## Changes
- Fix parameter shadowing in `InitModelCfg` to correctly persist ASR config.

## Impact
- ASR/voice input works as expected.
- No impact to other features.

## Verification
1. Set `LLM.AsrModel` (AppID/Token/Cluster).
2. Start services and try voice input in the browser.
3. ASR returns recognized text.
